### PR TITLE
Enable log levels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.21'
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netascode/go-sdwan
 
-go 1.18
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
This PR uses the logging levels of the [slog](https://go.dev/blog/slog) package.

Note1: this change slightly alters the output (e.g., `[DEBUG]` -> ` DEBUG `) and is half-assed. 
Note2: if output breaking is not an issue, we can utilize the full power of structured logging in a PR later.

Meanwhile, the loglevel configuration is a matter of calling `slog.SetLogLoggerLevel(loglevel)` in the example as (the default level is Info):

```go
package main

import (
	"log/slog"

	"github.com/netascode/go-sdwan"
)

func main() {
	slog.SetLogLoggerLevel(slog.LevelDebug)

	client, _ := sdwan.NewClient("1.1.1.1", "user", "pwd", true)

	res, _ := client.Get("/admin/resourcegroup")
	println(res.Get("0.id").String())
}
```
