### PR TITLE
Add API token authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ package main
 import "github.com/netascode/go-sdwan"
 
 func main() {
-    client, _ := sdwan.NewClient("1.1.1.1", "user", "pwd", true)
+    client, _ := sdwan.NewClient("1.1.1.1", true, sdwan.WithLogin("user", "pwd"))
 
     res, _ := client.Get("/admin/resourcegroup")
     println(res.Get("0.id").String())
@@ -37,7 +37,7 @@ package main
 import "github.com/netascode/go-sdwan"
 
 func main() {
-    client, _ := sdwan.NewClientToken("1.1.1.1", "mytoken", true)
+    client, _ := sdwan.NewClient("1.1.1.1", true, sdwan.WithToken("mytoken"))
 
     res, _ := client.Get("/admin/resourcegroup")
     println(res.Get("0.id").String())

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ func main() {
 }
 ```
 
+### Token Authentication
+
+Instead of username/password, you can authenticate with a pre-provisioned API token:
+
+```go
+package main
+
+import "github.com/netascode/go-sdwan"
+
+func main() {
+    client, _ := sdwan.NewClientToken("1.1.1.1", "mytoken", true)
+
+    res, _ := client.Get("/admin/resourcegroup")
+    println(res.Get("0.id").String())
+}
+```
+
 This will print something like:
 
 ```

--- a/client.go
+++ b/client.go
@@ -59,8 +59,9 @@ type Client struct {
 // NewClient creates a new SDWAN HTTP client.
 // Pass modifiers in to modify the behavior of the client, e.g.
 //
-//	client, _ := NewClient("vmanage1.cisco.com", "user", "password", true, RequestTimeout(120))
-func NewClient(url, usr, pwd string, insecure bool, mods ...func(*Client)) (Client, error) {
+//	client, _ := NewClient("vmanage1.cisco.com", true, WithLogin("user", "password"), RequestTimeout(120))
+//	client, _ := NewClient("vmanage1.cisco.com", true, WithToken("mytoken"))
+func NewClient(url string, insecure bool, mods ...func(*Client)) (Client, error) {
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
 
@@ -74,8 +75,6 @@ func NewClient(url, usr, pwd string, insecure bool, mods ...func(*Client)) (Clie
 	client := Client{
 		HttpClient:          &httpClient,
 		Url:                 url,
-		Usr:                 usr,
-		Pwd:                 pwd,
 		Insecure:            insecure,
 		MaxRetries:          DefaultMaxRetries,
 		BackoffMinDelay:     DefaultBackoffMinDelay,
@@ -87,41 +86,28 @@ func NewClient(url, usr, pwd string, insecure bool, mods ...func(*Client)) (Clie
 	for _, mod := range mods {
 		mod(&client)
 	}
+
+	if client.ApiToken == "" && client.Usr == "" {
+		return client, fmt.Errorf("no authentication method configured, use WithLogin or WithToken")
+	}
+
 	return client, nil
 }
 
-// NewClientToken creates a new SDWAN HTTP client using a pre-provisioned API token.
-// The token is sent as a Bearer token in the Authorization header, skipping the
-// username/password login flow.
-//
-//	client, _ := NewClientToken("vmanage1.cisco.com", "mytoken", true, RequestTimeout(120))
-func NewClientToken(url, apiToken string, insecure bool, mods ...func(*Client)) (Client, error) {
-	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
-
-	cookieJar, _ := cookiejar.New(nil)
-	httpClient := http.Client{
-		Timeout:   60 * time.Second,
-		Transport: tr,
-		Jar:       cookieJar,
+// WithLogin configures username/password authentication.
+func WithLogin(usr, pwd string) func(*Client) {
+	return func(client *Client) {
+		client.Usr = usr
+		client.Pwd = pwd
 	}
+}
 
-	client := Client{
-		HttpClient:          &httpClient,
-		Url:                 url,
-		ApiToken:            apiToken,
-		Insecure:            insecure,
-		MaxRetries:          DefaultMaxRetries,
-		BackoffMinDelay:     DefaultBackoffMinDelay,
-		BackoffMaxDelay:     DefaultBackoffMaxDelay,
-		BackoffDelayFactor:  DefaultBackoffDelayFactor,
-		AuthenticationMutex: &sync.Mutex{},
+// WithToken configures API token authentication.
+// The token is sent as a Bearer token in the Authorization header.
+func WithToken(apiToken string) func(*Client) {
+	return func(client *Client) {
+		client.ApiToken = apiToken
 	}
-
-	for _, mod := range mods {
-		mod(&client)
-	}
-	return client, nil
 }
 
 // RequestTimeout modifies the HTTP request timeout from the default of 60 seconds.

--- a/client.go
+++ b/client.go
@@ -178,12 +178,11 @@ func (client Client) NewReq(method, uri string, body io.Reader, mods ...func(*Re
 //	req := client.NewReq("GET", "/admin/resourcegroup", nil)
 //	res, _ := client.Do(req)
 func (client *Client) Do(req Req) (Res, error) {
-	// add token
+	// add auth headers
 	if client.ApiToken != "" {
 		req.HttpReq.Header.Add("Authorization", "Bearer "+client.ApiToken)
-	} else {
-		req.HttpReq.Header.Add("X-XSRF-TOKEN", client.Token)
 	}
+	req.HttpReq.Header.Add("X-XSRF-TOKEN", client.Token)
 	// retain the request body across multiple attempts
 	var body []byte
 	if req.HttpReq.Body != nil {
@@ -375,14 +374,41 @@ func (client *Client) Login() error {
 func (client *Client) Authenticate() error {
 	var err error
 	client.AuthenticationMutex.Lock()
-	if client.ApiToken == "" && client.Token == "" {
-		err = client.Login()
+	if client.Token == "" {
+		if client.ApiToken != "" {
+			err = client.GetToken()
+		} else {
+			err = client.Login()
+		}
 	}
 	if err == nil && client.ManagerVersion == "" {
 		client.GetManagerVersion()
 	}
 	client.AuthenticationMutex.Unlock()
 	return err
+}
+
+// GetToken retrieves the XSRF token using API token authentication.
+func (client *Client) GetToken() error {
+	req := client.NewReq("GET", "/dataservice/client/token", nil)
+	req.HttpReq.Header.Add("Authorization", "Bearer "+client.ApiToken)
+	httpRes, err := client.HttpClient.Do(req.HttpReq)
+	if err != nil {
+		return err
+	}
+	defer httpRes.Body.Close()
+	if httpRes.StatusCode != 200 {
+		slog.Error(fmt.Sprintf("Token retrieval failed: StatusCode %v", httpRes.StatusCode))
+		return fmt.Errorf("authentication failed, token retrieval, status code: %v", httpRes.StatusCode)
+	}
+	token, _ := io.ReadAll(httpRes.Body)
+	if string(token) == "" {
+		slog.Error("Token retrieval failed: no token in payload")
+		return fmt.Errorf("authentication failed, no token in payload")
+	}
+	client.Token = string(token)
+	slog.Debug("Token retrieval successful")
+	return nil
 }
 
 // Get SDWAN Manager version

--- a/client.go
+++ b/client.go
@@ -38,6 +38,8 @@ type Client struct {
 	Usr string
 	// Pwd is the SDWAN password.
 	Pwd string
+	// ApiToken is a pre-provisioned API token for bearer token authentication.
+	ApiToken string
 	// Insecure determines if insecure https connections are allowed.
 	Insecure bool
 	// Maximum number of retries
@@ -74,6 +76,40 @@ func NewClient(url, usr, pwd string, insecure bool, mods ...func(*Client)) (Clie
 		Url:                 url,
 		Usr:                 usr,
 		Pwd:                 pwd,
+		Insecure:            insecure,
+		MaxRetries:          DefaultMaxRetries,
+		BackoffMinDelay:     DefaultBackoffMinDelay,
+		BackoffMaxDelay:     DefaultBackoffMaxDelay,
+		BackoffDelayFactor:  DefaultBackoffDelayFactor,
+		AuthenticationMutex: &sync.Mutex{},
+	}
+
+	for _, mod := range mods {
+		mod(&client)
+	}
+	return client, nil
+}
+
+// NewClientToken creates a new SDWAN HTTP client using a pre-provisioned API token.
+// The token is sent as a Bearer token in the Authorization header, skipping the
+// username/password login flow.
+//
+//	client, _ := NewClientToken("vmanage1.cisco.com", "mytoken", true, RequestTimeout(120))
+func NewClientToken(url, apiToken string, insecure bool, mods ...func(*Client)) (Client, error) {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+
+	cookieJar, _ := cookiejar.New(nil)
+	httpClient := http.Client{
+		Timeout:   60 * time.Second,
+		Transport: tr,
+		Jar:       cookieJar,
+	}
+
+	client := Client{
+		HttpClient:          &httpClient,
+		Url:                 url,
+		ApiToken:            apiToken,
 		Insecure:            insecure,
 		MaxRetries:          DefaultMaxRetries,
 		BackoffMinDelay:     DefaultBackoffMinDelay,
@@ -143,7 +179,11 @@ func (client Client) NewReq(method, uri string, body io.Reader, mods ...func(*Re
 //	res, _ := client.Do(req)
 func (client *Client) Do(req Req) (Res, error) {
 	// add token
-	req.HttpReq.Header.Add("X-XSRF-TOKEN", client.Token)
+	if client.ApiToken != "" {
+		req.HttpReq.Header.Add("Authorization", "Bearer "+client.ApiToken)
+	} else {
+		req.HttpReq.Header.Add("X-XSRF-TOKEN", client.Token)
+	}
 	// retain the request body across multiple attempts
 	var body []byte
 	if req.HttpReq.Body != nil {
@@ -335,7 +375,7 @@ func (client *Client) Login() error {
 func (client *Client) Authenticate() error {
 	var err error
 	client.AuthenticationMutex.Lock()
-	if client.Token == "" {
+	if client.ApiToken == "" && client.Token == "" {
 		err = client.Login()
 	}
 	if err == nil && client.ManagerVersion == "" {

--- a/client_test.go
+++ b/client_test.go
@@ -27,6 +27,12 @@ func authenticatedTestClient() Client {
 	return client
 }
 
+func tokenAuthTestClient() Client {
+	client, _ := NewClientToken(testURL, "ABC", true, MaxRetries(0))
+	gock.InterceptClient(client.HttpClient)
+	return client
+}
+
 // ErrReader implements the io.Reader interface and fails on Read.
 type ErrReader struct{}
 
@@ -211,4 +217,44 @@ func TestClientPut(t *testing.T) {
 		})
 	_, err = client.Put("/url", "{}")
 	assert.Error(t, err)
+}
+
+// TestNewClientToken tests the NewClientToken function.
+func TestNewClientToken(t *testing.T) {
+	client, _ := NewClientToken(testURL, "mytoken", true, RequestTimeout(120))
+	assert.Equal(t, "mytoken", client.ApiToken)
+	assert.Equal(t, "", client.Usr)
+	assert.Equal(t, "", client.Pwd)
+	assert.Equal(t, client.HttpClient.Timeout, 120*time.Second)
+}
+
+// TestClientTokenAuthGet tests that token auth uses Authorization Bearer header.
+func TestClientTokenAuthGet(t *testing.T) {
+	defer gock.Off()
+	client := tokenAuthTestClient()
+
+	// Mock the about endpoint for GetManagerVersion
+	gock.New(testURL).Get("/dataservice/client/about").Reply(200).JSON(map[string]map[string]string{"data": {"version": "20.12.3"}})
+
+	// Success - verify Bearer header is sent
+	gock.New(testURL).
+		Get("/dataservice/url").
+		MatchHeader("Authorization", "Bearer ABC").
+		Reply(200)
+	_, err := client.Get("/url")
+	assert.NoError(t, err)
+}
+
+// TestClientTokenAuthAuthenticate tests that Authenticate skips login when ApiToken is set.
+func TestClientTokenAuthAuthenticate(t *testing.T) {
+	defer gock.Off()
+	client := tokenAuthTestClient()
+
+	// Only mock about endpoint - login endpoints should NOT be called
+	gock.New(testURL).Get("/dataservice/client/about").Reply(200).JSON(map[string]map[string]string{"data": {"version": "20.12.3"}})
+
+	err := client.Authenticate()
+	assert.NoError(t, err)
+	assert.Equal(t, "", client.Token) // Token field stays empty, ApiToken is used instead
+	assert.Equal(t, "20.12.3", client.ManagerVersion)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -16,7 +16,7 @@ const (
 )
 
 func testClient() Client {
-	client, _ := NewClient(testURL, "usr", "pwd", true, MaxRetries(0))
+	client, _ := NewClient(testURL, true, WithLogin("usr", "pwd"), MaxRetries(0))
 	gock.InterceptClient(client.HttpClient)
 	return client
 }
@@ -28,7 +28,7 @@ func authenticatedTestClient() Client {
 }
 
 func tokenAuthTestClient() Client {
-	client, _ := NewClientToken(testURL, "ABC", true, MaxRetries(0))
+	client, _ := NewClient(testURL, true, WithToken("ABC"), MaxRetries(0))
 	gock.InterceptClient(client.HttpClient)
 	return client
 }
@@ -43,8 +43,14 @@ func (r ErrReader) Read(buf []byte) (int, error) {
 
 // TestNewClient tests the NewClient function.
 func TestNewClient(t *testing.T) {
-	client, _ := NewClient(testURL, "usr", "pwd", true, RequestTimeout(120))
+	client, _ := NewClient(testURL, true, WithLogin("usr", "pwd"), RequestTimeout(120))
 	assert.Equal(t, client.HttpClient.Timeout, 120*time.Second)
+	assert.Equal(t, "usr", client.Usr)
+	assert.Equal(t, "pwd", client.Pwd)
+
+	// No auth method configured
+	_, err := NewClient(testURL, true)
+	assert.Error(t, err)
 }
 
 // TestClientLogin tests the Client::Login method.
@@ -219,9 +225,9 @@ func TestClientPut(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestNewClientToken tests the NewClientToken function.
+// TestNewClientToken tests the NewClient function with WithToken.
 func TestNewClientToken(t *testing.T) {
-	client, _ := NewClientToken(testURL, "mytoken", true, RequestTimeout(120))
+	client, _ := NewClient(testURL, true, WithToken("mytoken"), RequestTimeout(120))
 	assert.Equal(t, "mytoken", client.ApiToken)
 	assert.Equal(t, "", client.Usr)
 	assert.Equal(t, "", client.Pwd)

--- a/client_test.go
+++ b/client_test.go
@@ -228,33 +228,26 @@ func TestNewClientToken(t *testing.T) {
 	assert.Equal(t, client.HttpClient.Timeout, 120*time.Second)
 }
 
-// TestClientTokenAuthGet tests that token auth uses Authorization Bearer header.
+// TestClientTokenAuthGet tests that token auth sends both Authorization Bearer and X-XSRF-TOKEN headers.
 func TestClientTokenAuthGet(t *testing.T) {
 	defer gock.Off()
 	client := tokenAuthTestClient()
 
+	// Mock token retrieval for XSRF token
+	gock.New(testURL).
+		Get("/dataservice/client/token").
+		MatchHeader("Authorization", "Bearer ABC").
+		Reply(200).
+		BodyString("XYZ")
 	// Mock the about endpoint for GetManagerVersion
 	gock.New(testURL).Get("/dataservice/client/about").Reply(200).JSON(map[string]map[string]string{"data": {"version": "20.12.3"}})
 
-	// Success - verify Bearer header is sent
+	// Success - verify both headers are sent
 	gock.New(testURL).
 		Get("/dataservice/url").
 		MatchHeader("Authorization", "Bearer ABC").
+		MatchHeader("X-XSRF-TOKEN", "XYZ").
 		Reply(200)
 	_, err := client.Get("/url")
 	assert.NoError(t, err)
-}
-
-// TestClientTokenAuthAuthenticate tests that Authenticate skips login when ApiToken is set.
-func TestClientTokenAuthAuthenticate(t *testing.T) {
-	defer gock.Off()
-	client := tokenAuthTestClient()
-
-	// Only mock about endpoint - login endpoints should NOT be called
-	gock.New(testURL).Get("/dataservice/client/about").Reply(200).JSON(map[string]map[string]string{"data": {"version": "20.12.3"}})
-
-	err := client.Authenticate()
-	assert.NoError(t, err)
-	assert.Equal(t, "", client.Token) // Token field stays empty, ApiToken is used instead
-	assert.Equal(t, "20.12.3", client.ManagerVersion)
 }


### PR DESCRIPTION
Adds NewClientToken() constructor for authenticating with a pre-provisioned bearer token, skipping the username/password login flow.

This enables users to interact with Cisco hosted controllers without raising a case to create a local user(non SSO) for API interaction with this client.